### PR TITLE
Skip special values for CheckinsMinMaxIDLimit.

### DIFF
--- a/user_checkins.go
+++ b/user_checkins.go
@@ -28,9 +28,13 @@ func (u *UserService) Checkins(username string) ([]*Checkin, *http.Response, err
 // 50 checkins is the maximum number of checkins which may be returned by
 // one call.
 func (u *UserService) CheckinsMinMaxIDLimit(username string, minID int, maxID int, limit int) ([]*Checkin, *http.Response, error) {
-	return u.client.getCheckins("user/checkins/"+username, url.Values{
-		"min_id": []string{strconv.Itoa(minID)},
-		"max_id": []string{strconv.Itoa(maxID)},
-		"limit":  []string{strconv.Itoa(limit)},
-	})
+	v := url.Values{}
+	if minID != 0 {
+		v.Set("min_id", strconv.Itoa(minID))
+	}
+	if maxID != math.MaxInt32 {
+		v.Set("max_id", strconv.Itoa(maxID))
+	}
+	v.Set("limit", strconv.Itoa(limit))
+	return u.client.getCheckins("user/checkins/"+username, v)
 }


### PR DESCRIPTION
The untappd api has become stricter and does no longer allow math.MaxInt32 for checkin max id. I have fixed it for me with this patch. I was getting "500 [invalid_param]: This 'max_id' is invalid. Please provide a valid Checkin ID as your max_id". 

O for minId used to indicate that we want all checkins, and math.MaxInt32
is used when the maxId is unknown. The untappd api has become stricter
and does no longer allow invalid ids for these parameters. Patch changes
the sent requests to avoid sending anything for these values.
