### PR TITLE
{auth,response}_test: Go 1.6 allows non-ASCII bytes in hostnames

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -13,7 +13,7 @@ import (
 // TestNewAuthHandler verifies that NewAuthHandler returns appropriate errors
 // for various types of input parameters.
 func TestNewAuthHandler(t *testing.T) {
-	const badURL = "http://%a0.com"
+	const badURL = "http://%20.com"
 
 	var tests = []struct {
 		description  string

--- a/response_test.go
+++ b/response_test.go
@@ -178,7 +178,7 @@ func Test_responseTimeUnmarshalJSON(t *testing.T) {
 // from the Untappd APIv4.
 func Test_responseURLUnmarshalJSON(t *testing.T) {
 	// Bad URL used to validate URL parsing
-	badURL := "http://www.%a0.com/foo"
+	badURL := "http://www.%20.com/foo"
 
 	var tests = []struct {
 		description string


### PR DESCRIPTION
Go 1.6 started to accept non-ASCII bytes in hostnames with [chang 17385](https://go-review.googlesource.com/#/c/17385/). This causes two tests to runtime error. Changing the hex to be within the ASCII spaces makes the test behave as expected on Go 1.5 and 1.6.
