### PR TITLE
venue_info: Add Foursquare, Top Beers and Checkins fields.

### DIFF
--- a/venue.go
+++ b/venue.go
@@ -20,6 +20,9 @@ type Venue struct {
 
 	// Location of this venue.
 	Location VenueLocation
+
+	// Foursquare data.
+	Foursquare VenueFoursquare
 }
 
 // VenueService is a "service" which allows access to API methods involving
@@ -40,26 +43,35 @@ type VenueLocation struct {
 	Longitude float64 `json:"lng"`
 }
 
+// VenueLocation represents an Untappd venu's Foursquare data, and contains
+// the venue's Foursquare ID and URL.
+type VenueFoursquare struct {
+	ID  string `json:"foursquare_id"`
+	URL string `json:"foursquare_url"`
+}
+
 // rawVenue is the raw JSON representation of an Untappd venue.  Its data is
 // unmarshaled from JSON and then exported to a Venue struct.
 type rawVenue struct {
-	ID       int           `json:"venue_id"`
-	Name     string        `json:"venue_name"`
-	Updated  responseTime  `json:"last_updated"`
-	Category string        `json:"primary_category"`
-	Public   bool          `json:"public_venue"`
-	Location VenueLocation `json:"location"`
+	ID         int             `json:"venue_id"`
+	Name       string          `json:"venue_name"`
+	Updated    responseTime    `json:"last_updated"`
+	Category   string          `json:"primary_category"`
+	Public     bool            `json:"public_venue"`
+	Location   VenueLocation   `json:"location"`
+	Foursquare VenueFoursquare `json:"foursquare"`
 }
 
 // export creates an exported Venue from a rawVenue struct, allowing for
 // more useful structures to be created for client consumption.
 func (r *rawVenue) export() *Venue {
 	return &Venue{
-		ID:       r.ID,
-		Name:     r.Name,
-		Updated:  time.Time(r.Updated),
-		Category: r.Category,
-		Public:   r.Public,
-		Location: r.Location,
+		ID:         r.ID,
+		Name:       r.Name,
+		Updated:    time.Time(r.Updated),
+		Category:   r.Category,
+		Public:     r.Public,
+		Location:   r.Location,
+		Foursquare: r.Foursquare,
 	}
 }

--- a/venue.go
+++ b/venue.go
@@ -26,6 +26,9 @@ type Venue struct {
 
 	// Popular beers at this venue.
 	TopBeers []*Beer
+
+	// Checkins at this venue.
+	Checkins []*Checkin
 }
 
 // VenueService is a "service" which allows access to API methods involving
@@ -76,6 +79,10 @@ type rawVenue struct {
 			Brewery rawBrewery `json:"brewery"`
 		} `json:"items"`
 	} `json:"top_beers"`
+	Checkins struct {
+		Count int           `json:"count"`
+		Items []*rawCheckin `json:"items"`
+	} `json:"checkins"`
 }
 
 // export creates an exported Venue from a rawVenue struct, allowing for
@@ -87,6 +94,11 @@ func (r *rawVenue) export() *Venue {
 		beers[i].Brewery = r.TopBeers.Items[i].Brewery.export()
 	}
 
+	checkins := make([]*Checkin, r.Checkins.Count)
+	for i := range r.Checkins.Items {
+		checkins[i] = r.Checkins.Items[i].export()
+	}
+
 	return &Venue{
 		ID:         r.ID,
 		Name:       r.Name,
@@ -96,5 +108,6 @@ func (r *rawVenue) export() *Venue {
 		Location:   r.Location,
 		Foursquare: r.Foursquare,
 		TopBeers:   beers,
+		Checkins:   checkins,
 	}
 }

--- a/venue_info_test.go
+++ b/venue_info_test.go
@@ -89,6 +89,15 @@ func TestClientVenueInfoOK(t *testing.T) {
 	if c := v.Foursquare.URL; c != foursquareURL {
 		t.Fatalf("unexpected Foursquare.URL: %q != %q", c, foursquareURL)
 	}
+
+	topBeerName := "Beer Name"
+	if c := v.TopBeers[0].Name; c != topBeerName {
+		t.Fatalf("unexpected TopBeers[0].Name: %q != %q", c, topBeerName)
+	}
+	topBeerBrewery := "Brewery Name"
+	if c := v.TopBeers[0].Brewery.Name; c != topBeerBrewery {
+		t.Fatalf("unexpected TopBeers[0].Brewery.Name: %q != %q", c, topBeerBrewery)
+	}
 }
 
 // venueInfoTestClient builds upon testClient, and adds additional sanity checks
@@ -126,16 +135,34 @@ var venueJSON = []byte(`
   },
   "notifications": {},
   "response": {
-  "venue": {
-    "venue_id": 1021,
-    "venue_name": "Bell's Eccentric Cafe & General Store",
-    "location": {
-      "venue_city": "Kalamazoo"
-    },
-    "foursquare": {
-      "foursquare_id": "4a8f8efcf964a520761520e3",
-      "foursquare_url": "http://4sq.com/dheQpl"
+    "venue": {
+      "venue_id": 1021,
+      "venue_name": "Bell's Eccentric Cafe & General Store",
+      "location": {
+        "venue_city": "Kalamazoo"
+      },
+      "foursquare": {
+        "foursquare_id": "4a8f8efcf964a520761520e3",
+        "foursquare_url": "http://4sq.com/dheQpl"
+      },
+      "top_beers": {
+        "offset": 0,
+        "limit": 15,
+        "count": 1,
+        "items": [
+          {
+            "created_at": "Mon, 02 May 2016 00:48:33 +0000",
+            "total_count": 1,
+            "your_count": 0,
+            "beer": {
+              "beer_name": "Beer Name"
+            },
+            "brewery": {
+              "brewery_name": "Brewery Name"
+            }
+          }
+        ]
+      }
     }
-  }
   }
 }`)

--- a/venue_info_test.go
+++ b/venue_info_test.go
@@ -81,6 +81,14 @@ func TestClientVenueInfoOK(t *testing.T) {
 	if c := v.Location.City; c != venueCity {
 		t.Fatalf("unexpected Location.City: %q != %q", c, venueCity)
 	}
+	foursquareID := "4a8f8efcf964a520761520e3"
+	if c := v.Foursquare.ID; c != foursquareID {
+		t.Fatalf("unexpected Foursquare.ID: %q != %q", c, foursquareID)
+	}
+	foursquareURL := "http://4sq.com/dheQpl"
+	if c := v.Foursquare.URL; c != foursquareURL {
+		t.Fatalf("unexpected Foursquare.URL: %q != %q", c, foursquareURL)
+	}
 }
 
 // venueInfoTestClient builds upon testClient, and adds additional sanity checks
@@ -123,6 +131,10 @@ var venueJSON = []byte(`
     "venue_name": "Bell's Eccentric Cafe & General Store",
     "location": {
       "venue_city": "Kalamazoo"
+    },
+    "foursquare": {
+      "foursquare_id": "4a8f8efcf964a520761520e3",
+      "foursquare_url": "http://4sq.com/dheQpl"
     }
   }
   }

--- a/venue_info_test.go
+++ b/venue_info_test.go
@@ -90,13 +90,19 @@ func TestClientVenueInfoOK(t *testing.T) {
 		t.Fatalf("unexpected Foursquare.URL: %q != %q", c, foursquareURL)
 	}
 
-	topBeerName := "Beer Name"
-	if c := v.TopBeers[0].Name; c != topBeerName {
-		t.Fatalf("unexpected TopBeers[0].Name: %q != %q", c, topBeerName)
+	beerName := "Beer Name"
+	if c := v.TopBeers[0].Name; c != beerName {
+		t.Fatalf("unexpected TopBeers[0].Name: %q != %q", c, beerName)
 	}
-	topBeerBrewery := "Brewery Name"
-	if c := v.TopBeers[0].Brewery.Name; c != topBeerBrewery {
-		t.Fatalf("unexpected TopBeers[0].Brewery.Name: %q != %q", c, topBeerBrewery)
+	beerBrewery := "Brewery Name"
+	if c := v.TopBeers[0].Brewery.Name; c != beerBrewery {
+		t.Fatalf("unexpected TopBeers[0].Brewery.Name: %q != %q", c, beerBrewery)
+	}
+	if c := v.Checkins[0].Beer.Name; c != beerName {
+		t.Fatalf("unexpected Checkins[0].Beer.Name: %q != %q", c, beerName)
+	}
+	if c := v.Checkins[0].Brewery.Name; c != beerBrewery {
+		t.Fatalf("unexpected Checkins[0].Brewery.Name: %q != %q", c, beerBrewery)
 	}
 }
 
@@ -154,6 +160,20 @@ var venueJSON = []byte(`
             "created_at": "Mon, 02 May 2016 00:48:33 +0000",
             "total_count": 1,
             "your_count": 0,
+            "beer": {
+              "beer_name": "Beer Name"
+            },
+            "brewery": {
+              "brewery_name": "Brewery Name"
+            }
+          }
+        ]
+      },
+      "checkins": {
+        "count": 1,
+        "items": [
+          {
+            "created_at": "Sat, 21 May 2016 00:15:40 +0000",
             "beer": {
               "beer_name": "Beer Name"
             },


### PR DESCRIPTION
The tests contain fairly stripped down data.

It would probably be better to just take a full dump from the API explorer and use that (with some censorship), but I didn't want to change too much about them.
