### PR TITLE
Fix content type error

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -355,7 +356,7 @@ func (c *Client) getCheckins(endpoint string, q url.Values) ([]*Checkin, *http.R
 // encountered.
 func checkResponse(res *http.Response) error {
 	// Ensure correct content type
-	if cType := res.Header.Get("Content-Type"); cType != jsonContentType {
+	if cType := res.Header.Get("Content-Type"); strings.HasPrefix(cType, jsonContentType) {
 		return fmt.Errorf("expected %s content type, but received %s", jsonContentType, cType)
 	}
 

--- a/client.go
+++ b/client.go
@@ -356,7 +356,7 @@ func (c *Client) getCheckins(endpoint string, q url.Values) ([]*Checkin, *http.R
 // encountered.
 func checkResponse(res *http.Response) error {
 	// Ensure correct content type
-	if cType := res.Header.Get("Content-Type"); strings.HasPrefix(cType, jsonContentType) {
+	if cType := res.Header.Get("Content-Type"); !strings.HasPrefix(cType, jsonContentType) {
 		return fmt.Errorf("expected %s content type, but received %s", jsonContentType, cType)
 	}
 


### PR DESCRIPTION
Fixes #10 

It looks like untappd started returning charset in the content-type header, which broke the content-type check. The fix checks that the content type starts with application/json.