### PR TITLE
cmd/untappdctl: fix the usage of codegangsta/cli

### DIFF
--- a/cmd/untappdctl/beer.go
+++ b/cmd/untappdctl/beer.go
@@ -10,12 +10,12 @@ import (
 
 // beerCommand allows access to untappd.Client.Beer methods, such as beer
 // information by ID, and query by search term.
-func beerCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag cli.StringFlag, minIDFlag cli.IntFlag, maxIDFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func beerCommand(offsetFlag, limitFlag *cli.IntFlag, sortFlag *cli.StringFlag, minIDFlag, maxIDFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "beer",
 		Aliases: []string{"be"},
 		Usage:   "query for beer information, by beer ID or name",
-		Subcommands: []cli.Command{
+		Subcommands: []*cli.Command{
 			beerCheckinsCommand(limitFlag, minIDFlag, maxIDFlag),
 			beerInfoCommand(),
 			beerSearchCommand(offsetFlag, limitFlag, sortFlag),
@@ -25,8 +25,8 @@ func beerCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag cli.Str
 
 // beerCheckinsCommand allows access to the untappd.Client.Beer.Checkins method, which
 // can query for information about recent checkins for a beer, by ID.
-func beerCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func beerCheckinsCommand(limitFlag, minIDFlag, maxIDFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "checkins",
 		Aliases: []string{"c"},
 		Usage:   "query for recent checkins for a beer, by ID",
@@ -36,7 +36,7 @@ func beerCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag
 			maxIDFlag,
 		},
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			// Check for valid integer ID
 			id, err := strconv.Atoi(mustStringArg(ctx, "beer ID"))
 			checkAtoiError(err)
@@ -59,19 +59,20 @@ func beerCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag
 
 			// Print out checkins in human-readable format
 			printCheckins(checkins)
+			return nil
 		},
 	}
 }
 
 // beerInfoCommand allows access to the untappd.Client.Beer.Info method, which
 // can query for information about a beer, by ID.
-func beerInfoCommand() cli.Command {
-	return cli.Command{
+func beerInfoCommand() *cli.Command {
+	return &cli.Command{
 		Name:    "info",
 		Aliases: []string{"i"},
 		Usage:   "query for beer information, by ID",
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			// Check for valid integer ID
 			id, err := strconv.Atoi(mustStringArg(ctx, "beer ID"))
 			checkAtoiError(err)
@@ -86,14 +87,15 @@ func beerInfoCommand() cli.Command {
 
 			// Print out beer in human-readable format
 			printBeers([]*untappd.Beer{beer})
+			return nil
 		},
 	}
 }
 
 // beerSearchCommand allows access to the untappd.Client.Beer.Search method, which
 // can search for information about beers, by search term.
-func beerSearchCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag cli.StringFlag) cli.Command {
-	return cli.Command{
+func beerSearchCommand(offsetFlag, limitFlag *cli.IntFlag, sortFlag *cli.StringFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "search",
 		Aliases: []string{"s"},
 		Usage:   "search for beers, by brewery and/or beer name",
@@ -102,7 +104,7 @@ func beerSearchCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag c
 			limitFlag,
 		},
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			offset, limit, sort := offsetLimitSort(ctx)
 
 			// Query for beer's earned beers by name, e.g.
@@ -121,6 +123,7 @@ func beerSearchCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag c
 
 			// Print out beers in human-readable format
 			printBeers(beers)
+			return nil
 		},
 	}
 }

--- a/cmd/untappdctl/brewery.go
+++ b/cmd/untappdctl/brewery.go
@@ -10,12 +10,12 @@ import (
 
 // breweryCommand allows access to untappd.Client.Brewery methods, such as brewery
 // information by ID, and query by search term.
-func breweryCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func breweryCommand(offsetFlag, limitFlag, minIDFlag, maxIDFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "brewery",
 		Aliases: []string{"br"},
 		Usage:   "query for brewery information, by brewery ID or name",
-		Subcommands: []cli.Command{
+		Subcommands: []*cli.Command{
 			breweryCheckinsCommand(limitFlag, minIDFlag, maxIDFlag),
 			breweryInfoCommand(),
 			brewerySearchCommand(offsetFlag, limitFlag),
@@ -25,8 +25,8 @@ func breweryCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, minIDFlag cli
 
 // breweryCheckinsCommand allows access to the untappd.Client.Brewery.Checkins method, which
 // can query for information about recent checkins for beers made by a brewery, by ID.
-func breweryCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func breweryCheckinsCommand(limitFlag, minIDFlag, maxIDFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "checkins",
 		Aliases: []string{"c"},
 		Usage:   "query for recent checkins for beers from a specified brewery, by ID",
@@ -36,7 +36,7 @@ func breweryCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDF
 			maxIDFlag,
 		},
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			// Check for valid integer ID
 			id, err := strconv.Atoi(mustStringArg(ctx, "brewery ID"))
 			checkAtoiError(err)
@@ -59,19 +59,20 @@ func breweryCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDF
 
 			// Print out checkins in human-readable format
 			printCheckins(checkins)
+			return nil
 		},
 	}
 }
 
 // breweryInfoCommand allows access to the untappd.Client.Brewery.Info method, which
 // can query for information about a brewery, by ID.
-func breweryInfoCommand() cli.Command {
-	return cli.Command{
+func breweryInfoCommand() *cli.Command {
+	return &cli.Command{
 		Name:    "info",
 		Aliases: []string{"i"},
 		Usage:   "query for brewery information, by ID",
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			// Check for valid integer ID
 			id, err := strconv.Atoi(mustStringArg(ctx, "brewery ID"))
 			checkAtoiError(err)
@@ -86,14 +87,15 @@ func breweryInfoCommand() cli.Command {
 
 			// Print out brewery in human-readable format
 			printBreweries([]*untappd.Brewery{brewery})
+			return nil
 		},
 	}
 }
 
 // brewerySearchCommand allows access to the untappd.Client.Brewery.Search method, which
 // can search for information about breweries, by search term.
-func brewerySearchCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func brewerySearchCommand(offsetFlag, limitFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "search",
 		Aliases: []string{"s"},
 		Usage:   "search for breweries, by brewery name",
@@ -102,7 +104,7 @@ func brewerySearchCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag) cli.Com
 			limitFlag,
 		},
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			offset, limit, _ := offsetLimitSort(ctx)
 
 			// Query for brewery's earned breweries by name, e.g.
@@ -120,6 +122,7 @@ func brewerySearchCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag) cli.Com
 
 			// Print out breweries in human-readable format
 			printBreweries(breweries)
+			return nil
 		},
 	}
 }

--- a/cmd/untappdctl/local.go
+++ b/cmd/untappdctl/local.go
@@ -12,12 +12,12 @@ import (
 
 // localCommand allows access to untappd.Client.Local methods, such as local
 // checkins by latitude and longitude.
-func localCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func localCommand(limitFlag, minIDFlag, maxIDFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "local",
 		Aliases: []string{"l"},
 		Usage:   "query for local area checkins, by latitude and longitude",
-		Subcommands: []cli.Command{
+		Subcommands: []*cli.Command{
 			localCheckinsCommand(limitFlag, minIDFlag, maxIDFlag),
 		},
 	}
@@ -26,8 +26,8 @@ func localCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag cli.In
 // localCheckinsCommand allows access to the untappd.Client.Local.Checkins method, which
 // can query for information about recent checkins for a local area, by latitude, longitude,
 // and several other parameters.
-func localCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func localCheckinsCommand(limitFlag, minIDFlag, maxIDFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "checkins",
 		Aliases: []string{"c"},
 		Usage:   "query for recent checkins for a local area, by latitude and longitude",
@@ -35,19 +35,19 @@ func localCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFla
 			limitFlag,
 			minIDFlag,
 			maxIDFlag,
-			cli.IntFlag{
+			&cli.IntFlag{
 				Name:  "radius",
 				Value: 25,
 				Usage: "checkin radius around latitude,longitude pair",
 			},
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name:  "unit",
 				Value: string(untappd.DistanceMiles),
 				Usage: fmt.Sprintf("units for radius, either %q or %q", untappd.DistanceMiles, untappd.DistanceKilometers),
 			},
 		},
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			// Check for valid latitude and longitude pair
 			pair := strings.Split(mustStringArg(ctx, "latitude,longitude pair"), ",")
 			if len(pair) != 2 {
@@ -87,6 +87,7 @@ func localCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFla
 
 			// Print out checkins in human-readable format
 			printCheckins(checkins)
+			return nil
 		},
 	}
 }

--- a/cmd/untappdctl/main.go
+++ b/cmd/untappdctl/main.go
@@ -23,8 +23,8 @@ func main() {
 	app.Name = appName
 	app.Usage = "query and display information from Untappd APIv4"
 	app.Version = "0.0.1"
-	app.Authors = []cli.Author{
-		cli.Author{
+	app.Authors = []*cli.Author{
+		&cli.Author{
 			Name:  "Matt Layher",
 			Email: "mdlayher@gmail.com",
 		},
@@ -33,55 +33,55 @@ func main() {
 	// Add global flags for Untappd API client ID, client secret, and
 	// authenticated access token
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:   "client_id",
-			Usage:  "client ID parameter for Untappd APIv4",
-			EnvVar: "UNTAPPD_ID",
+		&cli.StringFlag{
+			Name:    "client_id",
+			Usage:   "client ID parameter for Untappd APIv4",
+			EnvVars: []string{"UNTAPPD_ID"},
 		},
-		cli.StringFlag{
-			Name:   "client_secret",
-			Usage:  "client secret parameter for Untappd APIv4",
-			EnvVar: "UNTAPPD_SECRET",
+		&cli.StringFlag{
+			Name:    "client_secret",
+			Usage:   "client secret parameter for Untappd APIv4",
+			EnvVars: []string{"UNTAPPD_SECRET"},
 		},
-		cli.StringFlag{
-			Name:   "access_token",
-			Usage:  "authenticated access token for Untappd APIv4",
-			EnvVar: "UNTAPPD_TOKEN",
+		&cli.StringFlag{
+			Name:    "access_token",
+			Usage:   "authenticated access token for Untappd APIv4",
+			EnvVars: []string{"UNTAPPD_TOKEN"},
 		},
 	}
 
 	// Frequently used flags for paging and sorting results, with their
 	// default Untappd API values
-	offsetFlag := cli.IntFlag{
+	offsetFlag := &cli.IntFlag{
 		Name:  "offset",
 		Value: 0,
 		Usage: "starting offset for API query results",
 	}
-	limitFlag := cli.IntFlag{
+	limitFlag := &cli.IntFlag{
 		Name:  "limit",
 		Value: 25,
 		Usage: "maximum number of API query results",
 	}
-	sortFlag := cli.StringFlag{
+	sortFlag := &cli.StringFlag{
 		Name:  "sort",
 		Value: string(untappd.SortDate),
 		Usage: fmt.Sprintf("sort type for API query results (options: %s)", untappd.Sorts()),
 	}
 
 	// Flags used to specify minimum and maximum checkin IDs
-	minIDFlag := cli.IntFlag{
+	minIDFlag := &cli.IntFlag{
 		Name:  "min_id",
 		Value: 0,
 		Usage: "minimum checkin ID for API query results",
 	}
-	maxIDFlag := cli.IntFlag{
+	maxIDFlag := &cli.IntFlag{
 		Name:  "max_id",
 		Value: math.MaxInt32,
 		Usage: "maximum checkin ID for API query results",
 	}
 
 	// Add commands mirroring available untappd.Client services
-	app.Commands = []cli.Command{
+	app.Commands = []*cli.Command{
 		authCommand(limitFlag, minIDFlag, maxIDFlag),
 		beerCommand(offsetFlag, limitFlag, sortFlag, minIDFlag, maxIDFlag),
 		breweryCommand(offsetFlag, limitFlag, minIDFlag, maxIDFlag),
@@ -105,13 +105,13 @@ func untappdClient(ctx *cli.Context) *untappd.Client {
 	var err error
 
 	// Always prefer authenticated access token, if available
-	token := ctx.GlobalString("access_token")
+	token := ctx.String("access_token")
 	if token != "" {
 		c, err = untappd.NewAuthenticatedClient(token, nil)
 	} else {
 		c, err = untappd.NewClient(
-			ctx.GlobalString("client_id"),
-			ctx.GlobalString("client_secret"),
+			ctx.String("client_id"),
+			ctx.String("client_secret"),
 			nil,
 		)
 	}

--- a/cmd/untappdctl/user.go
+++ b/cmd/untappdctl/user.go
@@ -9,12 +9,12 @@ import (
 
 // userCommand allows access to untappd.Client.User methods, such as user
 // information, checked in beers, friends, badges, and wish list.
-func userCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag cli.StringFlag, minIDFlag cli.IntFlag, maxIDFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func userCommand(offsetFlag, limitFlag *cli.IntFlag, sortFlag *cli.StringFlag, minIDFlag, maxIDFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "user",
 		Aliases: []string{"u"},
 		Usage:   "query for user information, by username",
-		Subcommands: []cli.Command{
+		Subcommands: []*cli.Command{
 			userBadgesCommand(offsetFlag, limitFlag),
 			userBeersCommand(offsetFlag, limitFlag, sortFlag),
 			userCheckinsCommand(limitFlag, minIDFlag, maxIDFlag),
@@ -27,8 +27,8 @@ func userCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag cli.Str
 
 // userBadgesCommand allows access to the untappd.Client.User.Badges method, which
 // can query for information about a user's badges, by username.
-func userBadgesCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func userBadgesCommand(offsetFlag, limitFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "badges",
 		Aliases: []string{"ba"},
 		Usage:   "query for badges a user has earned, by username",
@@ -37,7 +37,7 @@ func userBadgesCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag) cli.Comman
 			limitFlag,
 		},
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			offset, limit, _ := offsetLimitSort(ctx)
 
 			// Query for user's earned badges by username, e.g.
@@ -55,14 +55,15 @@ func userBadgesCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag) cli.Comman
 
 			// Print out badges in human-readable format
 			printBadges(badges)
+			return nil
 		},
 	}
 }
 
 // userBeersCommand allows access to the untappd.Client.User.Beers method, which
 // can query for information about a user's checked in beers, by username.
-func userBeersCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag cli.StringFlag) cli.Command {
-	return cli.Command{
+func userBeersCommand(offsetFlag, limitFlag *cli.IntFlag, sortFlag *cli.StringFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "beers",
 		Aliases: []string{"be"},
 		Usage:   "query for beers a user has checked in, by username",
@@ -72,7 +73,7 @@ func userBeersCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag cl
 			sortFlag,
 		},
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			offset, limit, sort := offsetLimitSort(ctx)
 
 			// Query for user's checked in beers by username, e.g.
@@ -91,14 +92,15 @@ func userBeersCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag cl
 
 			// Print out beers in human-readable format
 			printBeers(beers)
+			return nil
 		},
 	}
 }
 
 // userCheckinsCommand allows access to the untappd.Client.User.Checkins method, which
 // can query for information about a user's checked in beers, by username.
-func userCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func userCheckinsCommand(limitFlag, minIDFlag, maxIDFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "checkins",
 		Aliases: []string{"c"},
 		Usage:   "query for recent user checkins, by username",
@@ -108,7 +110,7 @@ func userCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag
 			maxIDFlag,
 		},
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			minID, maxID, limit := ctx.Int("min_id"), ctx.Int("max_id"), ctx.Int("limit")
 
 			// Query for user's checkins by username, e.g.
@@ -127,14 +129,15 @@ func userCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag
 
 			// Print out checkins in human-readable format
 			printCheckins(checkins)
+			return nil
 		},
 	}
 }
 
 // userFriendsCommand allows access to the untappd.Client.User.Friends method, which
 // can query for information about a user's friends, by username.
-func userFriendsCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func userFriendsCommand(offsetFlag, limitFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "friends",
 		Aliases: []string{"f"},
 		Usage:   "query for a user's friends, by username",
@@ -143,7 +146,7 @@ func userFriendsCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag) cli.Comma
 			limitFlag,
 		},
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			offset, limit, _ := offsetLimitSort(ctx)
 
 			// Query for user's friends by username, e.g.
@@ -161,19 +164,20 @@ func userFriendsCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag) cli.Comma
 
 			// Print out users in human-readable format
 			printUsers(friends, false)
+			return nil
 		},
 	}
 }
 
 // userInfoCommand allows access to the untappd.Client.User.Info method, which
 // can query for information about a user, by username.
-func userInfoCommand() cli.Command {
-	return cli.Command{
+func userInfoCommand() *cli.Command {
+	return &cli.Command{
 		Name:    "info",
 		Aliases: []string{"i"},
 		Usage:   "query for user information, such as ID, real name, etc. by username",
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			// Query for user by username, e.g. "untappdctl user info mdlayher"
 			c := untappdClient(ctx)
 			user, res, err := c.User.Info(mustStringArg(ctx, "username"), false)
@@ -184,14 +188,15 @@ func userInfoCommand() cli.Command {
 
 			// Print out user in human-readable format
 			printUsers([]*untappd.User{user}, true)
+			return nil
 		},
 	}
 }
 
 // userWishListCommand allows access to the untappd.Client.User.WishList method,
 // which can query for information about a user's wish list beers, by username.
-func userWishListCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag cli.StringFlag) cli.Command {
-	return cli.Command{
+func userWishListCommand(offsetFlag, limitFlag *cli.IntFlag, sortFlag *cli.StringFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "wishlist",
 		Aliases: []string{"w"},
 		Usage:   "query for beers a user has on their wishlist, by username",
@@ -201,7 +206,7 @@ func userWishListCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag
 			sortFlag,
 		},
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			offset, limit, sort := offsetLimitSort(ctx)
 
 			// Query for user wishlist beers by username,
@@ -220,6 +225,7 @@ func userWishListCommand(offsetFlag cli.IntFlag, limitFlag cli.IntFlag, sortFlag
 
 			// Print out beers in human-readable format
 			printBeers(beers)
+			return nil
 		},
 	}
 }

--- a/cmd/untappdctl/venue.go
+++ b/cmd/untappdctl/venue.go
@@ -10,12 +10,12 @@ import (
 
 // venueCommand allows access to untappd.Client.Venue methods, such as venue
 // information by ID.
-func venueCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func venueCommand(limitFlag, minIDFlag, maxIDFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "venue",
 		Aliases: []string{"v"},
 		Usage:   "query for venue information, by venue ID",
-		Subcommands: []cli.Command{
+		Subcommands: []*cli.Command{
 			venueCheckinsCommand(limitFlag, minIDFlag, maxIDFlag),
 			venueInfoCommand(),
 		},
@@ -24,8 +24,8 @@ func venueCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag cli.In
 
 // venueCheckinsCommand allows access to the untappd.Client.Venue.Checkins method, which
 // can query for information about recent checkins at a specified venue, by ID.
-func venueCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFlag cli.IntFlag) cli.Command {
-	return cli.Command{
+func venueCheckinsCommand(limitFlag, minIDFlag, maxIDFlag *cli.IntFlag) *cli.Command {
+	return &cli.Command{
 		Name:    "checkins",
 		Aliases: []string{"c"},
 		Usage:   "query for recent checkins at a specified venue, by ID",
@@ -35,7 +35,7 @@ func venueCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFla
 			maxIDFlag,
 		},
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			// Check for valid integer ID
 			id, err := strconv.Atoi(mustStringArg(ctx, "venue ID"))
 			checkAtoiError(err)
@@ -58,19 +58,20 @@ func venueCheckinsCommand(limitFlag cli.IntFlag, minIDFlag cli.IntFlag, maxIDFla
 
 			// Print out checkins in human-readable format
 			printCheckins(checkins)
+			return nil
 		},
 	}
 }
 
 // venueInfoCommand allows access to the untappd.Client.Venue.Info method, which
 // can query for information about a venue, by ID.
-func venueInfoCommand() cli.Command {
-	return cli.Command{
+func venueInfoCommand() *cli.Command {
+	return &cli.Command{
 		Name:    "info",
 		Aliases: []string{"i"},
 		Usage:   "query for venue information, by ID",
 
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) error {
 			// Check for valid integer ID
 			id, err := strconv.Atoi(mustStringArg(ctx, "venue ID"))
 			checkAtoiError(err)
@@ -85,6 +86,7 @@ func venueInfoCommand() cli.Command {
 
 			// Print out venue in human-readable format
 			printVenues([]*untappd.Venue{venue})
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
codegangsta/cli made several backward-incompatible changes and our code needed to change correspondingly.

Longer term, it may be worth swapping it out for a library that doesn't make regular breaking changes ... or at least start making releases that use modules to freeze our dependencies.