### PR TITLE
Rename codegangsta/cli to urfave/cli/v2

### DIFF
--- a/cmd/untappdctl/auth.go
+++ b/cmd/untappdctl/auth.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli/v2"
 	"github.com/mdlayher/untappd"
 )
 

--- a/cmd/untappdctl/beer.go
+++ b/cmd/untappdctl/beer.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli/v2"
 	"github.com/mdlayher/untappd"
 )
 

--- a/cmd/untappdctl/brewery.go
+++ b/cmd/untappdctl/brewery.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli/v2"
 	"github.com/mdlayher/untappd"
 )
 

--- a/cmd/untappdctl/local.go
+++ b/cmd/untappdctl/local.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli/v2"
 	"github.com/mdlayher/untappd"
 )
 

--- a/cmd/untappdctl/main.go
+++ b/cmd/untappdctl/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli/v2"
 	"github.com/mdlayher/untappd"
 )
 

--- a/cmd/untappdctl/user.go
+++ b/cmd/untappdctl/user.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli/v2"
 	"github.com/mdlayher/untappd"
 )
 

--- a/cmd/untappdctl/venue.go
+++ b/cmd/untappdctl/venue.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli/v2"
 	"github.com/mdlayher/untappd"
 )
 


### PR DESCRIPTION
The repository moved location a while ago, and although github still serves it at the old URL we get errors when trying to use it with Go modules:

    github.com/codegangsta/cli: github.com/codegangsta/cli@v1.22.5: parsing go.mod:
    module declares its path as: github.com/urfave/cli
            but was required as: github.com/codegangsta/cli
